### PR TITLE
Provide ways to override package.json and node_modules locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ By default, plugin searches for `@thundra/core` package in the following directo
 * Any directory in `modules.paths` (default search paths used by `require`)
 * \<directory that contains handler file for a specific function\>/node_modules
 * The directory that is given as follows:
+
+**Globally**
+```bash
+custom:
+  thundra:
+    node_modules_path: <directory that contains @thundra/core>
+```
+
+**Or per function:**
 ```bash
 functions:
   hello-world-test:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ functions:
 By default, plugin searches for `@thundra/core` package in the following directories, `@thundra/core` package should be available in at least one of them:
 
 * Any directory in `modules.paths` (default search paths used by `require`)
-* \<directory that contains handler file for a spesific function\>/node_modules
+* \<directory that contains handler file for a specific function\>/node_modules
 * The directory that is given as follows:
 ```bash
 functions:
@@ -89,6 +89,21 @@ functions:
       thundra:
         node_modules_path: <directory that contains @thundra/core>
 ```
+
+### Defining custom `package.json` path [Node.js]
+By default, this plugin searches for the `package.json` file in the root serverless application directory and if the file is found, it ensures that the 
+`@thundra/core` package is installed. There are repositories that use multiple `package.json` files and the default one is not the one where the module 
+dependencies are defined (this is particularly common with monorepo directory structures). The `package_json_path` can be used to specify the directory 
+where to look for the correct `package.json` file.
+
+This can be defined globally as follows:
+```bash
+custom:
+  thundra:
+    package_json_path: <directory that contains correct package.json>
+```
+
+Alternatively, this can be overriden using the serverless cli argument `--prefix=<directory` or the `npm_config_prefix` environment variable.
 
 ### Specify Layer version [Java]
 By default, plugin uses default Java layer version of the plugin and it might be changed by each version of plugin.

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -48,8 +48,9 @@ exports.generateWrapperExt = function(func) {
  * @param {Object} func The function to wrap.
  * @return {String} The wrapper code.
  */
-exports.generateWrapperCode = function(func) {
-    let customNodePath = _.get(func, 'custom.thundra.node_modules_path', '')
+exports.generateWrapperCode = function(func, config) {
+    let customNodePath =
+        func.node_modules_path || config.node_modules_path || ''
     return THUNDRA_LANG_WRAPPERS[func.language]
         .replace(/PATH/g, func.relativePath)
         .replace(/METHOD/g, func.method)

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -50,7 +50,9 @@ exports.generateWrapperExt = function(func) {
  */
 exports.generateWrapperCode = function(func, config) {
     let customNodePath =
-        func.node_modules_path || config.node_modules_path || ''
+        _.get(func, 'custom.thundra.node_modules_path') ||
+        config.node_modules_path ||
+        ''
     return THUNDRA_LANG_WRAPPERS[func.language]
         .replace(/PATH/g, func.relativePath)
         .replace(/METHOD/g, func.method)

--- a/src/index.js
+++ b/src/index.js
@@ -57,8 +57,7 @@ class ServerlessThundraPlugin {
     constructor(serverless = {}, options) {
         this.serverless = serverless
         this.prefix =
-            ((this.serverless.service.custom || { thundra: {} }).thundra || {})
-                .package_json_path ||
+            _.get(serverless.service, 'custom.thundra.package_json_path') ||
             options.prefix ||
             process.env.npm_config_prefix ||
             this.serverless.config.servicePath

--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,11 @@ class ServerlessThundraPlugin {
     constructor(serverless = {}, options) {
         this.serverless = serverless
         this.prefix =
+            ((this.serverless.service.custom || { thundra: {} }).thundra || {})
+                .package_json_path ||
             options.prefix ||
-            this.serverless.config.servicePath ||
-            process.env.npm_config_prefix
+            process.env.npm_config_prefix ||
+            this.serverless.config.servicePath
         this.funcs = []
         this.originalServicePath = this.serverless.config.servicePath
         this.commands = {


### PR DESCRIPTION
In monorepo approaches, it is common to have multiple package.json files that define different module dependencies. In such situations, the check for the `@thundra/code` module would fail because this dependency might not be defined in the serverless's application root directory. This PR provides a way to override this path.
It also fixes the `npm_config_prefix` environment variable precedence - as this was being checked after the serverless servicePath which is never undefined. 
Also, the existing way to override the `node_modules` path by providing a different directory with `node_modules_path` was not taking effect so this is being fixed in this PR to provide the behaviour as documented in the README.